### PR TITLE
Bring icons inline with Pixel, divide vertical hotseat padding, reseat Google Search bar

### DIFF
--- a/res/xml/device_profiles.xml
+++ b/res/xml/device_profiles.xml
@@ -138,10 +138,10 @@
         launcher:numFolderRows="4"
         launcher:numFolderColumns="4"
         launcher:minAllAppsPredictionColumns="4"
-        launcher:iconSize="64"
-        launcher:iconTextSize="14.4"
+        launcher:iconSize="60"
+        launcher:iconTextSize="13"
         launcher:numHotseatIcons="5"
-        launcher:hotseatIconSize="56"
+        launcher:hotseatIconSize="60"
         launcher:defaultLayoutId="@xml/default_workspace_5x5"
         />
 

--- a/src/com/android/launcher3/DeviceProfile.java
+++ b/src/com/android/launcher3/DeviceProfile.java
@@ -535,6 +535,11 @@ public class DeviceProfile {
         } else {
             // For phones, layout the hotseat without any bottom margin
             // to ensure that we have space for the folders
+            if (mInsets.bottom < hotseatBarTopPaddingPx) {
+                hotseatBarTopPaddingPx = (mInsets.bottom + hotseatBarTopPaddingPx) / 2;
+                mInsets.bottom = hotseatBarTopPaddingPx;
+            }
+
             lp.gravity = Gravity.BOTTOM;
             lp.width = LayoutParams.MATCH_PARENT;
             lp.height = hotseatBarHeightPx + mInsets.bottom;

--- a/src/com/android/launcher3/QsbContainerView.java
+++ b/src/com/android/launcher3/QsbContainerView.java
@@ -154,7 +154,8 @@ public class QsbContainerView extends FrameLayout {
                         .getAppWidgetOptions(widgetId), opts)) {
                     mQsb.updateAppWidgetOptions(opts);
                 }
-                mQsb.setPadding(0, 0, 0, 0);
+                mQsb.setPadding(mQsb.getPaddingLeft(), 0, mQsb.getPaddingRight(), 0);
+                mQsb.setLayoutParams(new LauncherAppWidgetHostView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, android.view.Gravity.TOP));
                 return mQsb;
             }
 


### PR DESCRIPTION
OP3(T) Device Profile
iconSize 64 -> 60
hotseatIconSize 56 -> 60
iconTextSize 14.4 -> 13

If the bottom inset is smaller than the top inset, which is true when there is no soft navigation bar, balance the two so they are symmetrical while using the same amount of space.

Set the gravity to Top on the Google Search bar to shift it upwards on all DPIs and rotations. The latter is done programmatically because the widget's XML is overwritten before it reaches the code.